### PR TITLE
update-travis-and-rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,9 @@ AllCops:
 # with minimal friction, not forced to make a hard choice between
 # cutting tests or splitting up my test suites.
 #
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*.rb'
 Metrics/ClassLength:
   Max: 400
   Exclude:
@@ -47,95 +50,16 @@ Metrics/MethodLength:
 Layout:
   Enabled: false
 
+# As a group, the Style cops are bewilderingly opiniated.
+#
+# In some cases IMO they are harmful e.g. Style/TernaryParentheses.
+#
+# I reject these cops.
+#
+Style:
+  Enabled: false
+
 # I like a lot of the Lint tests, but not these.
 #
 Lint/AmbiguousBlockAssociation:           # obnoxiously rejects idiomatic Ruby
-  Enabled: false
-
-# This does no more than insist I type "format" instead of "sprintf",
-# where the two are aliases.
-#
-Style/FormatString:
-  Enabled: false
-
-# There is nothing wrong with Ruby 1.9 Hash syntax.
-#
-Style/HashSyntax:
-  Enabled: false
-
-# No.  Indeed, postfix if can often drive a line over 80 columns wide.
-#
-Style/IfUnlessModifier:
-  Enabled: false
-
-# No.  There is nothing wrong with "if !foo".
-#
-# As far as I'm concerned, "unless" is in poor taste because it means
-# I have to think in English in two different logical senses - and
-# English is a poor language for logical senses.
-#
-Style/NegatedIf:
-  Enabled: false
-
-# Too pedantic.
-#
-Style/NumericLiterals:
-  Enabled: false
-
-# "Do not use semicolons to terminate expressions."
-#
-# That's great when I terminate a single-line expression with a
-# redundant semicolo because I forget I'm not using C.
-#
-# But when I'm using a semicolon to separate two expressions there is
-# no other choice.  So this really ought to be Style/OneExprPerLine,
-# which I reject.
-#
-Style/Semicolon:
-  Enabled: false
-
-# No.
-#
-# Some lines must have '\"'.  It is ugly to use a mix of '"' and '\''
-# in LoCs which are close to one another.  Therefore, banning '"' if
-# '"' is not strictly necessary drives visual inconsistency.
-#
-Style/StringLiterals:
-  Enabled: false
-
-# This is the same kind of obnoxious pedantry which drove Hungarian
-# Notation.
-#
-# The [] literal syntax is perfectly servicable and there is no point
-# _tightly_ coupling it to the content of the array.  That's why we
-# have context-free grammers!
-#
-Style/SymbolArray:
-  Enabled: false
-
-# Shockingly, this cop requires us to *OMIT*, not *INCLUDE* parens in
-# ternery conditons.
-#
-# IMO this one is actively harmful in that it discourages attention to
-# clarity and avoiding some nasty precedence surprises.
-#
-Style/TernaryParentheses:
-  Enabled: false
-
-# I am a huge fan of using trailing commas when I break an argument
-# list down one-per line.
-#
-# As such, I reject this test.
-#
-Style/TrailingCommaInLiteral:
-  Enabled: false
-
-# Too pedantic.  I am starting to think I should switch from "opt out"
-# to "opt in" on the Style family.
-#
-Style/WordArray:
-  Enabled: false
-Style/YodaCondition:
-  Enabled: false
-Style/ZeroLengthPredicate:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 before_install:
-  - gem install bundler -v 1.14.6
+  - gem install bundler -v 1.16.1
   - gem install rubocop
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ before_install:
   - gem install rubocop
 rvm:
   - 2.1.6
+  - 2.2.9
+  - 2.4.3
+  - 2.5.0
 script:
-  - rubocop
-  - rake test
+  - bundle exec rubocop --display-cop-names --display-style-guide
+  - bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: ruby
 before_install:
   - gem install bundler -v 1.14.6
   - gem install rubocop
+services:
+  - redis-server
 rvm:
   - 2.1.6
   - 2.2.9
@@ -10,4 +12,4 @@ rvm:
   - 2.5.0
 script:
   - bundle exec rubocop --display-cop-names --display-style-guide
-  - bundle exec rake test
+  - bundle exec env REDIS_URL=redis://localhost:6379 rake test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# 0.0.5 (2018-03-26)
+- Expanded .travis.yml to cover more rvm versions.
+- Shrink Rubocop coverage to exclude `Style/*`.
+- Moves version history out into CHANGELOG.md.
+
+# 0.0.4 (2017-09-12)
+- Verified existing behavior w/r/t Redis::Namespace.
+- Added more details in Redis::ImpendingCrossSlotError.
+- Rubocop polish and defiance.
+- Redis::KeyHash::ClassMethods inner-inner class removed.
+- Redis::KeyHash changed to a class, not a module.
+- Redis::ImpendingCrossSlotError changed from ArgumentError to Redis::RuntimeError.
+
+# 0.0.3 (2017-08-29)
+
+- Fix :rc to match https://redis.io/topics/cluster-spec, added Rubocop checks.
+
+# 0.0.2 (2017-08-28)
+
+- Broke out into Prosperworks/redis-key_hash, make public.
+
+# 0.0.1 (prehistory)
+
+- Still in Prosperworks/ALI/vendor/gems/redis-key_hash.
+

--- a/lib/redis/key_hash/version.rb
+++ b/lib/redis/key_hash/version.rb
@@ -1,33 +1,5 @@
 class Redis
   class KeyHash
-    #
-    # Version plan/history:
-    #
-    # 0.0.1 - Still in Prosperworks/ALI/vendor/gems/redis-key_hash.
-    #
-    # 0.0.2 - Broke out into Prosperworks/redis-key_hash, make public.
-    #
-    # 0.0.3 - Fix :rc to match https://redis.io/topics/cluster-spec,
-    #         added Rubocop checks.
-    #
-    # 0.0.4 - Verified existing behavior w/r/t Redis::Namespace.
-    #
-    #         Added more details in Redis::ImpendingCrossSlotError.
-    #
-    #         Rubocop polish and defiance.
-    #
-    #         Redis::KeyHash::ClassMethods inner-inner class removed.
-    #
-    #         Redis::KeyHash changed to a class, not a module.
-    #
-    #         Redis::ImpendingCrossSlotError changed from
-    #         ArgumentError to Redis::RuntimeError.
-    #
-    # 0.1.0 - (future) Big README.md and Rdoc update, solicit feedback
-    #         from select external beta users.
-    #
-    # 0.2.0 - (future) Incorporate feedback, announce.
-    #
-    VERSION = '0.0.4'.freeze
+    VERSION = '0.0.5'.freeze
   end
 end

--- a/redis-key_hash.gemspec
+++ b/redis-key_hash.gemspec
@@ -3,10 +3,10 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'redis/key_hash/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "redis-key_hash"
+  spec.name          = 'redis-key_hash'
   spec.version       = Redis::KeyHash::VERSION
-  spec.authors       = ["jhwillett"]
-  spec.email         = ["jhw@prosperworks.com"]
+  spec.authors       = ['jhwillett']
+  spec.email         = ['jhw@prosperworks.com']
   spec.license       = 'MIT'
 
   spec.summary       = 'Tests Redis Cluster key hash slot agreement'
@@ -17,16 +17,17 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   # We use "foo: bar" syntax liberally, not the older ":foo => bar".
   # Possibly other Ruby 2-isms as well.
   #
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '~> 2.1'
 
-  spec.add_development_dependency "bundler",  "~> 1.14"
-  spec.add_development_dependency "rake",     "~> 10.5"
-  spec.add_development_dependency "minitest", "~> 5.10"
+  spec.add_development_dependency 'bundler',  '~> 1.16.1'
+  spec.add_development_dependency 'minitest', '~> 5.11.3'
+  spec.add_development_dependency 'rake',     '~> 12.3.1'
+  spec.add_development_dependency 'rubocop',  '~> 0.54.0'
 
   # This gem is pure Ruby, no weird dependencies.
   #

--- a/redis-key_hash.gemspec
+++ b/redis-key_hash.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   # We use "foo: bar" syntax liberally, not the older ":foo => bar".
   # Possibly other Ruby 2-isms as well.
   #
-  spec.required_ruby_version = '=> 2.1'
+  spec.required_ruby_version = '>= 2.1'
 
   spec.add_development_dependency 'bundler',  '~> 1.16.0'
   spec.add_development_dependency 'minitest', '~> 5.11.3'

--- a/redis-key_hash.gemspec
+++ b/redis-key_hash.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   # We use "foo: bar" syntax liberally, not the older ":foo => bar".
   # Possibly other Ruby 2-isms as well.
   #
-  spec.required_ruby_version = '~> 2.1'
+  spec.required_ruby_version = '=> 2.1'
 
-  spec.add_development_dependency 'bundler',  '~> 1.16.1'
+  spec.add_development_dependency 'bundler',  '~> 1.16.0'
   spec.add_development_dependency 'minitest', '~> 5.11.3'
   spec.add_development_dependency 'rake',     '~> 12.3.1'
   spec.add_development_dependency 'rubocop',  '~> 0.54.0'


### PR DESCRIPTION
PR for redis-key_hash.  Bumps version to 0.0.5.

Revises Rubocop policy to match redis-ick, adds CHANGELOG.md, updates runtime deps, expands TravisCI to test across more Ruby versions.